### PR TITLE
Add a installation guide and fix some errors in readme; update commands for building online package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,7 @@ offline_package: prepare_package
 	@$(TARCMD) -zcvf $(PKGNAME)-offline-installer-$(VERSIONTAG)${if ${ARCH},.${ARCH}}.tgz $(PKGTEMPPATH)
 
 	@rm -rf $(PACKAGEPATH)
+	@echo "######################### Offline package done! #########################"
 
 offline_package_one_step: compile compile_ui build offline_package
 # packageonestep: compile compile_ui build package
@@ -278,7 +279,7 @@ online_package: prepare_package
 	@$(TARCMD) -zcvf $(PKGNAME)-online-installer-$(VERSIONTAG)${if ${ARCH},.${ARCH}}.tgz $(PKGTEMPPATH)
 
 	@rm -rf $(PACKAGEPATH)
-	@echo "######################### Online package is packaged! #########################"
+	@echo "######################### Online package done! #########################"
 
 .PHONY: cleanall
 cleanall: cleanbinary cleanimage

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(BUILD_LIST): %_build:
 	$(DOCKERBUILD) -f $(MAKEWORKPATH)/$*/Dockerfile${if ${ARCH},.${ARCH}} . -t $(IMAGEPREFIX)_$(subst container/,,$*):$(VERSIONTAG)
 	
 $(RMIMG_LIST): %_rmi:
-	$(DOCKERRMIMAGE) -f $(IMAGEPREFIX)_$(subst container/,,$*):$(VERSIONTAG)
+	$(DOCKERRMIMAGE) -f openboard/$(IMAGEPREFIX)_$(subst container/,,$*):$(VERSIONTAG)
 
 #container/db_build:
 #	$(DOCKERBUILD) -f $(MAKEWORKPATH)/container/db/Dockerfile . -t $(IMAGEPREFIX)_mysql:latest
@@ -242,12 +242,7 @@ prepare_composefile:
 	@sed -i "s/__version__/$(VERSIONTAG)/g" $(MAKEWORKPATH)/archive/docker-compose${if ${ARCH},.${ARCH}}.yml
 	@sed -i "s/__version__/$(VERSIONTAG)/g" $(MAKEWORKPATH)/docker-compose-adminserver${if ${ARCH},.${ARCH}}.yml
 
-prepare_online_composefile:
-	@sed -i "s/image: /image: openboard\//g" $(MAKEWORKPATH)/docker-compose${if ${ARCH},.${ARCH}}.yml
-	@sed -i "s/image: /image: openboard\//g" $(MAKEWORKPATH)/archive/docker-compose${if ${ARCH},.${ARCH}}.yml
-	@sed -i "s/image: /image: openboard\//g" $(MAKEWORKPATH)/docker-compose-adminserver${if ${ARCH},.${ARCH}}.yml
-
-prepare_package:
+prepare_package: prepare_composefile
 	@if [ ! -d $(PKGTEMPPATH) ] ; then mkdir $(PKGTEMPPATH) ; fi
 	@if [ ! -d $(PKGTEMPPATH)/adminserver ] ; then mkdir -p $(PKGTEMPPATH)/adminserver ; fi
 	@if [ ! -d $(PKGTEMPPATH)/archive ] ; then mkdir -p $(PKGTEMPPATH)/archive ; fi
@@ -268,17 +263,18 @@ prepare_package:
 	@sed -i "s/..\/config/.\/config/" $(PKGTEMPPATH)/docker-compose.yml
 	@sed -i "s/..\/config/.\/config/" $(PKGTEMPPATH)/archive/docker-compose.yml
 
-package: prepare_composefile prepare_package
+offline_package: prepare_package
 	@echo "package images ..."
 	@$(DOCKERSAVE) -o $(PKGTEMPPATH)/$(IMAGEPREFIX)_deployment.$(VERSIONTAG).tgz $(PKG_LIST) k8s_install:1.19 gitlab-helper:1.0
 	@$(TARCMD) -zcvf $(PKGNAME)-offline-installer-$(VERSIONTAG)${if ${ARCH},.${ARCH}}.tgz $(PKGTEMPPATH)
 
 	@rm -rf $(PACKAGEPATH)
 
-packageonestep: compile compile_ui build package
+offline_package_one_step: compile compile_ui build offline_package
+# packageonestep: compile compile_ui build package
 #packageonestep: compile build package
 
-online_package: prepare_composefile prepare_online_composefile prepare_package
+online_package: prepare_package
 	@$(TARCMD) -zcvf $(PKGNAME)-online-installer-$(VERSIONTAG)${if ${ARCH},.${ARCH}}.tgz $(PKGTEMPPATH)
 
 	@rm -rf $(PACKAGEPATH)

--- a/make/dev/archive/docker-compose.arm64v8.yml
+++ b/make/dev/archive/docker-compose.arm64v8.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/log/Dockerfile.arm64v8
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../../
       dockerfile: make/dev/container/db/Dockerfile.arm64v8
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -39,7 +39,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/gogits/Dockerfile.arm64v8
-    image: dev_gogits:dev
+    image: openboard/dev_gogits:dev
     restart: always
     volumes:
       - ../../config/gogits/conf/app.ini:/tmp/conf/app.ini
@@ -61,7 +61,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/jenkins/Dockerfile.arm64v8
-    image: dev_jenkins:dev
+    image: openboard/dev_jenkins:dev
     restart: always
     networks:
       - board
@@ -87,7 +87,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/apiserver/Dockerfile.arm64v8
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -119,7 +119,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/tokenserver/Dockerfile.arm64v8
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -138,7 +138,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/proxy/Dockerfile.arm64v8
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -162,7 +162,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/dev/archive/docker-compose.mips.yml
+++ b/make/dev/archive/docker-compose.mips.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/log/Dockerfile.mips
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../../
       dockerfile: make/dev/container/db/Dockerfile.mips
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -39,7 +39,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/gogits/Dockerfile.mips
-    image: dev_gogits:dev
+    image: openboard/dev_gogits:dev
     restart: always
     volumes:
       - ../../config/gogits/conf/app.ini:/tmp/conf/app.ini
@@ -61,7 +61,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/jenkins/Dockerfile.mips
-    image: dev_jenkins:dev
+    image: openboard/dev_jenkins:dev
     restart: always
     networks:
       - board
@@ -87,7 +87,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/apiserver/Dockerfile.mips
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -119,7 +119,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/tokenserver/Dockerfile.mips
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -138,7 +138,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/proxy/Dockerfile.mips
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -162,7 +162,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/dev/archive/docker-compose.yml
+++ b/make/dev/archive/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/log/Dockerfile
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../../
       dockerfile: make/dev/container/db/Dockerfile
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -44,7 +44,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/gogits/Dockerfile
-    image: dev_gogits:dev
+    image: openboard/dev_gogits:dev
     restart: always
     volumes:
       - ../../config/gogits/conf/app.ini:/tmp/conf/app.ini
@@ -66,7 +66,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/jenkins/Dockerfile
-    image: dev_jenkins:dev
+    image: openboard/dev_jenkins:dev
     restart: always
     networks:
       - board
@@ -92,7 +92,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/apiserver/Dockerfile
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -122,7 +122,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/tokenserver/Dockerfile
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -141,7 +141,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/proxy/Dockerfile
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -168,7 +168,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/grafana/Dockerfile
-    image: dev_grafana:dev
+    image: openboard/dev_grafana:dev
     restart: always
     volumes:
       - /data/board/grafana/data:/var/lib/grafana
@@ -190,7 +190,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/elasticsearch/Dockerfile
-    image: dev_elasticsearch:dev
+    image: openboard/dev_elasticsearch:dev
     restart: always
     env_file:
       - ../../config/elasticsearch/env
@@ -216,7 +216,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/kibana/Dockerfile
-    image: dev_kibana:dev
+    image: openboard/dev_kibana:dev
     restart: always
     env_file:
       - ../../config/kibana/env
@@ -236,7 +236,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/chartmuseum/Dockerfile
-    image: dev_chartmuseum:dev
+    image: openboard/dev_chartmuseum:dev
     restart: always
     networks:
       - board
@@ -256,7 +256,7 @@ services:
     build:
       context: ../../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/dev/docker-compose-adminserver.yml
+++ b/make/dev/docker-compose-adminserver.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/adminserver/Dockerfile
-    image: dev_adminserver:dev
+    image: openboard/dev_adminserver:dev
     restart: always
     volumes:
       - ../:/go/cfgfile
@@ -24,7 +24,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/proxy_adminserver/Dockerfile
-    image: dev_proxy_adminserver:dev
+    image: openboard/dev_proxy_adminserver:dev
     depends_on: 
       - adminserver
     restart: always

--- a/make/dev/docker-compose.arm64v8.yml
+++ b/make/dev/docker-compose.arm64v8.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/log/Dockerfile.arm64v8
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../
       dockerfile: make/dev/container/db/Dockerfile.arm64v8
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -39,7 +39,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/apiserver/Dockerfile.arm64v8
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -66,7 +66,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/tokenserver/Dockerfile.arm64v8
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -85,7 +85,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/proxy/Dockerfile.arm64v8
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -109,7 +109,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/dev/docker-compose.mips.yml
+++ b/make/dev/docker-compose.mips.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/log/Dockerfile.mips
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../
       dockerfile: make/dev/container/db/Dockerfile.mips
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -39,7 +39,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/apiserver/Dockerfile.mips
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -66,7 +66,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/tokenserver/Dockerfile.mips
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -85,7 +85,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/proxy/Dockerfile.mips
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -109,7 +109,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/dev/docker-compose.yml
+++ b/make/dev/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/log/Dockerfile
-    image: dev_log:dev
+    image: openboard/dev_log:dev
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -17,7 +17,7 @@ services:
     build: 
       context: ../../
       dockerfile: make/dev/container/db/Dockerfile
-    image: dev_db:dev
+    image: openboard/dev_db:dev
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -44,7 +44,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/apiserver/Dockerfile
-    image: dev_apiserver:dev
+    image: openboard/dev_apiserver:dev
     restart: always
     volumes:
       - ../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/go/bin/swagger:z
@@ -71,7 +71,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/tokenserver/Dockerfile
-    image: dev_tokenserver:dev
+    image: openboard/dev_tokenserver:dev
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -90,7 +90,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/proxy/Dockerfile
-    image: dev_proxy:dev
+    image: openboard/dev_proxy:dev
     networks:
       - board
     restart: always
@@ -117,7 +117,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/grafana/Dockerfile
-    image: dev_grafana:dev
+    image: openboard/dev_grafana:dev
     restart: always
     volumes:
       - /data/board/grafana/data:/var/lib/grafana
@@ -139,7 +139,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/elasticsearch/Dockerfile
-    image: dev_elasticsearch:dev
+    image: openboard/dev_elasticsearch:dev
     restart: always
     env_file:
       - ../config/elasticsearch/env
@@ -165,7 +165,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/kibana/Dockerfile
-    image: dev_kibana:dev
+    image: openboard/dev_kibana:dev
     restart: always
     env_file:
       - ../config/kibana/env
@@ -185,7 +185,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/chartmuseum/Dockerfile
-    image: dev_chartmuseum:dev
+    image: openboard/dev_chartmuseum:dev
     restart: always
     networks:
       - board
@@ -205,7 +205,7 @@ services:
     build:
       context: ../../
       dockerfile: make/dev/container/prometheus/Dockerfile
-    image: dev_prometheus:dev
+    image: openboard/dev_prometheus:dev
     restart: always
     networks:
       - board

--- a/make/release/archive/docker-compose.arm64v8.tpl
+++ b/make/release/archive/docker-compose.arm64v8.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -28,7 +28,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   gogits:
-    image: board_gogits:__version__
+    image: openboard/board_gogits:__version__
     restart: always
     volumes:
       - /data/board/gogits:/data:rw
@@ -47,7 +47,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "gogits"
   jenkins:
-    image: board_jenkins:__version__
+    image: openboard/board_jenkins:__version__
     restart: always
     networks:
       - board
@@ -69,7 +69,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "jenkins"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
 #     - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/usr/bin/swagger:z
@@ -95,7 +95,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -111,7 +111,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -132,7 +132,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - dvserver_net

--- a/make/release/archive/docker-compose.mips.tpl
+++ b/make/release/archive/docker-compose.mips.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -28,7 +28,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   gogits:
-    image: board_gogits:__version__
+    image: openboard/board_gogits:__version__
     restart: always
     volumes:
       - /data/board/gogits:/data:rw
@@ -47,7 +47,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "gogits"
   jenkins:
-    image: board_jenkins:__version__
+    image: openboard/board_jenkins:__version__
     restart: always
     networks:
       - board
@@ -69,7 +69,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "jenkins"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
 #     - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/usr/bin/swagger:z
@@ -95,7 +95,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -111,7 +111,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -132,7 +132,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - dvserver_net

--- a/make/release/archive/docker-compose.tpl
+++ b/make/release/archive/docker-compose.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -33,7 +33,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   gogits:
-    image: board_gogits:__version__
+    image: openboard/board_gogits:__version__
     restart: always
     volumes:
       - /data/board/gogits:/data:rw
@@ -52,7 +52,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "gogits"
   jenkins:
-    image: board_jenkins:__version__
+    image: openboard/board_jenkins:__version__
     restart: always
     networks:
       - board
@@ -74,7 +74,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "jenkins"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
 #     - ../../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/usr/bin/swagger:z
@@ -100,7 +100,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../../config/tokenserver/env
     restart: always
@@ -116,7 +116,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -140,7 +140,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   grafana:
-    image: board_grafana:__version__
+    image: openboard/board_grafana:__version__
     restart: always
     volumes:
       - /data/board/grafana/data:/var/lib/grafana
@@ -157,7 +157,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "grafana"
   elasticsearch:
-    image: board_elasticsearch:__version__
+    image: openboard/board_elasticsearch:__version__
     restart: always
     env_file:
       - ../../config/elasticsearch/env
@@ -180,7 +180,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "elasticsearch"
   kibana:
-    image: board_kibana:__version__
+    image: openboard/board_kibana:__version__
     restart: always
     env_file:
       - ../../config/kibana/env
@@ -197,7 +197,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "kibana"
   chartmuseum:
-    image: board_chartmuseum:__version__
+    image: openboard/board_chartmuseum:__version__
     restart: always
     networks:
       - board
@@ -214,7 +214,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "chartmuseum"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - board

--- a/make/release/docker-compose-adminserver.arm64v8.tpl
+++ b/make/release/docker-compose-adminserver.arm64v8.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   adminserver:
-    image: board_adminserver:__version__
+    image: openboard/board_adminserver:__version__
     restart: always
     volumes:
       - ../:/go/cfgfile
@@ -17,7 +17,7 @@ services:
     ports:
       - 8081:8080
   proxy_adminserver:
-    image: board_proxy_adminserver:__version__
+    image: openboard/board_proxy_adminserver:__version__
     depends_on: 
       - adminserver
     restart: always

--- a/make/release/docker-compose-adminserver.mips.tpl
+++ b/make/release/docker-compose-adminserver.mips.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   adminserver:
-    image: board_adminserver:__version__
+    image: openboard/board_adminserver:__version__
     restart: always
     volumes:
       - ../:/go/cfgfile
@@ -17,7 +17,7 @@ services:
     ports:
       - 8081:8080
   proxy_adminserver:
-    image: board_proxy_adminserver:__version__
+    image: openboard/board_proxy_adminserver:__version__
     depends_on: 
       - adminserver
     restart: always

--- a/make/release/docker-compose-adminserver.tpl
+++ b/make/release/docker-compose-adminserver.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   adminserver:
-    image: board_adminserver:__version__
+    image: openboard/board_adminserver:__version__
     restart: always
     volumes:
       - ../:/go/cfgfile
@@ -17,7 +17,7 @@ services:
     ports:
       - 8081:8080
   proxy_adminserver:
-    image: board_proxy_adminserver:__version__
+    image: openboard/board_proxy_adminserver:__version__
     depends_on: 
       - adminserver
     restart: always

--- a/make/release/docker-compose.arm64v8.tpl
+++ b/make/release/docker-compose.arm64v8.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -28,7 +28,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
       - /data/board/cert:/cert:rw
@@ -51,7 +51,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -67,7 +67,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -88,7 +88,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - dvserver_net

--- a/make/release/docker-compose.mips.tpl
+++ b/make/release/docker-compose.mips.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -28,7 +28,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
 #     - ../../tools/swagger/vendors/swagger-ui-2.1.4/dist:/usr/bin/swagger:z
@@ -52,7 +52,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -68,7 +68,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -89,7 +89,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - dvserver_net

--- a/make/release/docker-compose.tpl
+++ b/make/release/docker-compose.tpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   log:
-    image: board_log:__version__
+    image: openboard/board_log:__version__
     restart: always
     volumes:
       - /var/log/board/:/var/log/docker/
@@ -11,7 +11,7 @@ services:
     ports:
       - 1514:514
   db:
-    image: board_db:__version__
+    image: openboard/board_db:__version__
     restart: always
     volumes:
       - /data/board/database:/var/lib/mysql
@@ -33,7 +33,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "db"
   apiserver:
-    image: board_apiserver:__version__
+    image: openboard/board_apiserver:__version__
     restart: always
     volumes:
       - /data/board/cert:/cert:rw
@@ -56,7 +56,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "apiserver"
   tokenserver:
-    image: board_tokenserver:__version__
+    image: openboard/board_tokenserver:__version__
     env_file:
       - ../config/tokenserver/env
     restart: always
@@ -72,7 +72,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "tokenserver"
   proxy:
-    image: board_proxy:__version__
+    image: openboard/board_proxy:__version__
     networks:
       - board
     restart: always
@@ -96,7 +96,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "proxy"
   grafana:
-    image: board_grafana:__version__
+    image: openboard/board_grafana:__version__
     restart: always
     volumes:
       - /data/board/grafana/data:/var/lib/grafana
@@ -113,7 +113,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "grafana"
   elasticsearch:
-    image: board_elasticsearch:__version__
+    image: openboard/board_elasticsearch:__version__
     restart: always
     env_file:
       - ../config/elasticsearch/env
@@ -136,7 +136,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "elasticsearch"
   kibana:
-    image: board_kibana:__version__
+    image: openboard/board_kibana:__version__
     restart: always
     env_file:
       - ../config/kibana/env
@@ -153,7 +153,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "kibana"
   chartmuseum:
-    image: board_chartmuseum:__version__
+    image: openboard/board_chartmuseum:__version__
     restart: always
     networks:
       - board
@@ -170,7 +170,7 @@ services:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "chartmuseum"
   prometheus:
-    image: board_prometheus:__version__
+    image: openboard/board_prometheus:__version__
     restart: always
     networks:
       - board


### PR DESCRIPTION
## 1. Update Makefile for building online package.

### Offline package
You can pack an offline installation package by running these commands manually: 
``` bash
make compile
make compile_ui
make build
make offline_package
```
or running `make offline_package_one_step` to pack it in one step.

### Online package
Using `make online_package` to pack an online package. 

## 2. Update composefiles and makefile for updating images' base name

before: 
* dev_log:dev
* board_log:__version__

after: 
* openboard/dev_log:dev
* openboard/board_log:__version__