### PR TITLE
add extral images for offline k8s installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,10 @@ prepare_package: prepare_composefile
 
 offline_package: prepare_package
 	@echo "package images ..."
-	@$(DOCKERSAVE) -o $(PKGTEMPPATH)/$(IMAGEPREFIX)_deployment.$(VERSIONTAG).tgz $(PKG_LIST) k8s_install:1.19 gitlab-helper:1.0
+	@$(DOCKERPULL) docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+	@$(DOCKERPULL) docker.elastic.co/kibana/kibana:7.9.3
+	@$(DOCKERPULL) quay.io/fluentd_elasticsearch/fluentd:v3.0.4
+	@$(DOCKERSAVE) -o $(PKGTEMPPATH)/$(IMAGEPREFIX)_deployment.$(VERSIONTAG).tgz $(PKG_LIST) k8s_install:1.19 gitlab-helper:1.0 docker.elastic.co/elasticsearch/elasticsearch:7.9.3 docker.elastic.co/kibana/kibana:7.9.3 quay.io/fluentd_elasticsearch/fluentd:v3.0.4
 	@$(TARCMD) -zcvf $(PKGNAME)-offline-installer-$(VERSIONTAG)${if ${ARCH},.${ARCH}}.tgz $(PKGTEMPPATH)
 
 	@rm -rf $(PACKAGEPATH)

--- a/tools/chart-install.sh
+++ b/tools/chart-install.sh
@@ -161,6 +161,9 @@ function load_images {
 		docker push $image_registry_url/openboard/$image &> /dev/null
 		echo "Push $image_registry_url/openboard/$image ok"
 	done
+	docker tag docker.elastic.co/elasticsearch/elasticsearch:7.9.3 $image_registry_url/elasticsearch/elasticsearch:7.9.3
+	docker tag docker.elastic.co/kibana/kibana:7.9.3 $image_registry_url/kibana/kibana:7.9.3
+	docker tag quay.io/fluentd_elasticsearch/fluentd:v3.0.4 $image_registry_url/fluentd_elasticsearch/fluentd:v3.0.4
 }
 
 echo "[Step $item]: checking installation environment ..."; let item+=1


### PR DESCRIPTION
add three external images for efk.
later we need a more better way to fix the images transfer.
relate issue #921 