### PR TITLE
update node data converter for prometheus

### DIFF
--- a/src/apiserver/service/prometheus.go
+++ b/src/apiserver/service/prometheus.go
@@ -203,12 +203,15 @@ func nodeDataTypeConvert(data, which string) interface{} {
 	var err error
 	switch which {
 	case "storageUsed", "storageCap":
-		num, err = strconv.Atoi(data)
+		var num1 float64
+		num1, err = strconv.ParseFloat(data, 64)
+		num = int(num1)
 	case "CPU", "memory":
 		num, err = strconv.ParseFloat(data, 64)
 	}
 	if err != nil {
-		return nil
+		fmt.Println("got an error when converting to float:", err)
+		return 0
 	}
 	return num
 }


### PR DESCRIPTION
Convert to float64 at first, and then return int type. If it got an error, returns 0.
fix #1760